### PR TITLE
use with compilation database

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ using Fedora 38.  Improvements are welcome.
 
 ## Running
 
-To check the project, first configure NeoMutt, then run the main script with the
-source you wish to check:
+To check the project, first configure + build NeoMutt with a compilation database,
+then run the main script with the source you wish to check:
 
 ```sh
-./configure
+./configure --compile-commands && make
 iwyu.sh mutt/*.[ch]
 ```
 

--- a/bin/iwyu.sh
+++ b/bin/iwyu.sh
@@ -19,8 +19,6 @@ OPTS+=("-D__EXTENSIONS__")
 OPTS+=("-DNCURSES_WIDECHAR")
 OPTS+=("-DDEBUG")
 OPTS+=("-I .")
-OPTS+=("-I /usr/include/qdbm")
-OPTS+=("-I /usr/lib/gcc/x86_64-redhat-linux/13/include")
 OPTS+=("-Xiwyu --pch_in_code")
 OPTS+=("-Xiwyu --no_comments")
 


### PR DESCRIPTION
Using [iwyu with a compilation database](https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md#using-with-a-compilation-database) allows us to remove the hardcoded includes from the script.